### PR TITLE
✨ Implement Basic Menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import pygame
+import menu
 
 pygame.init()
 
@@ -8,15 +9,35 @@ screen_height = 600
 screen = pygame.display.set_mode((screen_width, screen_height))
 pygame.display.set_caption("My Game")
 
+# Game state
+game_state = "menu"
+start_rect = None
+quit_rect = None
+
 # Game loop
 running = True
 while running:
     for event in pygame.event.get():
         if event.type == pygame.QUIT:
             running = False
-    
+        
+        if game_state == "menu":
+            action = menu.handle_menu_input(event, start_rect, quit_rect)
+            if action == "start":
+                game_state = "game"
+            elif action == "quit":
+                running = False
+                
     # Clear the screen
     screen.fill((0, 0, 0))
+    
+    if game_state == "menu":
+        start_rect, quit_rect = menu.draw_menu(screen)
+    elif game_state == "game":
+        font = pygame.font.Font(None, 36)
+        text = font.render("Game", True, (255, 255, 255))
+        text_rect = text.get_rect(center=(screen.get_width() // 2, screen.get_height() // 2))
+        screen.blit(text, text_rect)
     
     # Update display
     pygame.display.flip()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+import pygame
+
+pygame.init()
+
+# Set screen dimensions
+screen_width = 800
+screen_height = 600
+screen = pygame.display.set_mode((screen_width, screen_height))
+pygame.display.set_caption("My Game")
+
+# Game loop
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+    
+    # Clear the screen
+    screen.fill((0, 0, 0))
+    
+    # Update display
+    pygame.display.flip()
+
+pygame.quit()

--- a/menu.py
+++ b/menu.py
@@ -1,0 +1,25 @@
+import pygame
+
+def draw_menu(screen):
+    font = pygame.font.Font(None, 36)
+    text = font.render("Main Menu", True, (255, 255, 255))
+    text_rect = text.get_rect(center=(screen.get_width() // 2, screen.get_height() // 4))
+    screen.blit(text, text_rect)
+    
+    start_text = font.render("Start", True, (255, 255, 255))
+    start_rect = start_text.get_rect(center=(screen.get_width() // 2, screen.get_height() // 2))
+    screen.blit(start_text, start_rect)
+
+    quit_text = font.render("Quit", True, (255, 255, 255))
+    quit_rect = quit_text.get_rect(center=(screen.get_width() // 2, screen.get_height() * 3 // 4))
+    screen.blit(quit_text, quit_rect)
+    
+    return start_rect, quit_rect
+
+def handle_menu_input(event, start_rect, quit_rect):
+    if event.type == pygame.MOUSEBUTTONDOWN:
+        if start_rect.collidepoint(event.pos):
+            return "start"
+        elif quit_rect.collidepoint(event.pos):
+            return "quit"
+    return None


### PR DESCRIPTION
This PR implements a basic menu using Pygame. It includes 'Start' and 'Quit' options. Clicking 'Start' will take you to a placeholder 'Game' screen. Clicking 'Quit' will exit the game.

This resolves issue #27.

To test:
1.  Run `main.py`.
2.  You should see a menu with 'Main Menu', 'Start', and 'Quit' options.
3.  Click 'Start' to navigate to the 'Game' screen.
4.  Click 'Quit' to exit the game.